### PR TITLE
feat: make app mobile and tablet friendly

### DIFF
--- a/src/components/time-tracker/ActiveFocusView.tsx
+++ b/src/components/time-tracker/ActiveFocusView.tsx
@@ -51,7 +51,7 @@ export function ActiveFocusView({
           <span>{activeProject.name}</span>
         </div>
 
-        <div style={styles.focusTimer}>{activeDurationLabel}</div>
+        <div className="focus-timer" style={styles.focusTimer}>{activeDurationLabel}</div>
 
         <div style={styles.focusActions}>
           <button type="button" onClick={onStopTimer} style={styles.stopAction}>

--- a/src/components/time-tracker/TrackerHeader.tsx
+++ b/src/components/time-tracker/TrackerHeader.tsx
@@ -14,7 +14,7 @@ export function TrackerHeader({ activeEntry, isToday, selectedDate, activeDurati
     <header className="tracker-header" style={styles.header}>
       <div style={styles.titleWrap}>
         <span style={styles.eyebrow}>{activeEntry ? 'Fokusmodus' : 'Arbeidsdag'}</span>
-        <h1 style={styles.title}>{activeEntry ? 'Timeren kjører' : 'Wikborg Tidsføring'}</h1>
+        <h1 className="tracker-title" style={styles.title}>{activeEntry ? 'Timeren kjører' : 'Wikborg Tidsføring'}</h1>
         <p style={styles.subtitle}>
           {activeEntry
             ? 'Vis bare det du trenger mens du jobber. Resten ligger i menyen til venstre.'

--- a/src/components/time-tracker/focusStyles.ts
+++ b/src/components/time-tracker/focusStyles.ts
@@ -65,7 +65,6 @@ export const focusStyles: Record<string, CSSProperties> = {
     fontWeight: 600,
   },
   focusTimer: {
-    fontSize: 72,
     lineHeight: 1,
     fontWeight: 800,
     letterSpacing: '-0.06em',

--- a/src/components/time-tracker/headerStyles.ts
+++ b/src/components/time-tracker/headerStyles.ts
@@ -25,7 +25,6 @@ export const headerStyles: Record<string, CSSProperties> = {
   },
   title: {
     margin: 0,
-    fontSize: 32,
     fontWeight: 700,
     lineHeight: 1.05,
   },

--- a/src/components/time-tracker/layoutStyles.ts
+++ b/src/components/time-tracker/layoutStyles.ts
@@ -6,7 +6,6 @@ export const layoutStyles: Record<string, CSSProperties> = {
     width: '100%',
     maxWidth: 'none',
     margin: 0,
-    padding: '0 24px 32px 0',
   },
   workspace: {
     display: 'grid',
@@ -15,8 +14,6 @@ export const layoutStyles: Record<string, CSSProperties> = {
     alignItems: 'start',
   },
   rail: {
-    position: 'sticky',
-    top: 0,
     display: 'flex',
     flexDirection: 'column',
     gap: 18,
@@ -24,10 +21,7 @@ export const layoutStyles: Record<string, CSSProperties> = {
     padding: '18px 8px',
     background: 'rgba(15, 23, 42, 0.86)',
     border: '1px solid var(--color-elevated-border)',
-    borderLeft: 'none',
-    borderRadius: '0 22px 22px 0',
     boxShadow: 'var(--shadow-soft)',
-    minHeight: '100vh',
   },
   railTop: {
     display: 'flex',
@@ -109,7 +103,5 @@ export const layoutStyles: Record<string, CSSProperties> = {
     display: 'flex',
     flexDirection: 'column',
     gap: 18,
-    paddingTop: 24,
-    paddingRight: 8,
   },
 }

--- a/src/index.css
+++ b/src/index.css
@@ -85,6 +85,37 @@ textarea:focus-visible {
   box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.18);
 }
 
+/* ── Shell & layout ── */
+
+.tracker-shell {
+  padding: 0 24px 32px 0;
+}
+
+.tracker-rail {
+  position: sticky;
+  top: 0;
+  min-height: 100vh;
+  border-left: none;
+  border-radius: 0 22px 22px 0;
+}
+
+.tracker-content-stack {
+  padding-top: 24px;
+  padding-right: 8px;
+}
+
+/* ── Responsive text ── */
+
+.tracker-title {
+  font-size: 32px;
+}
+
+.focus-timer {
+  font-size: 72px;
+}
+
+/* ── Grid layouts ── */
+
 .tracker-main {
   display: grid;
   grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
@@ -154,7 +185,13 @@ textarea:focus-visible {
   grid-column: 1;
 }
 
+/* ── Tablet (≤ 900px) ── */
+
 @media (max-width: 900px) {
+  .tracker-shell {
+    padding: 16px;
+  }
+
   .tracker-layout {
     grid-template-columns: 1fr;
   }
@@ -166,6 +203,8 @@ textarea:focus-visible {
   .tracker-rail {
     position: static;
     min-height: auto;
+    border-left: 1px solid var(--color-elevated-border);
+    border-radius: 16px;
   }
 
   .tracker-nav {
@@ -173,6 +212,16 @@ textarea:focus-visible {
     overflow-x: auto;
     padding-bottom: 2px;
     justify-content: flex-start;
+  }
+
+  .tracker-nav-button--active::before {
+    /* Fjern venstre-indikatoren når nav er horisontal */
+    display: none;
+  }
+
+  .tracker-content-stack {
+    padding-top: 0;
+    padding-right: 0;
   }
 
   .tracker-focus-grid {
@@ -189,11 +238,21 @@ textarea:focus-visible {
   .tracker-stat-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .tracker-title {
+    font-size: 24px;
+  }
+
+  .focus-timer {
+    font-size: 48px;
+  }
 }
+
+/* ── Mobil (≤ 640px) ── */
 
 @media (max-width: 640px) {
   .tracker-shell {
-    padding-right: 16px;
+    padding: 12px;
   }
 
   .tracker-header,
@@ -208,5 +267,13 @@ textarea:focus-visible {
 
   .tracker-stat-grid {
     grid-template-columns: 1fr;
+  }
+
+  .tracker-title {
+    font-size: 20px;
+  }
+
+  .focus-timer {
+    font-size: 40px;
   }
 }


### PR DESCRIPTION
Closes #2

- Rail sidebar stacker på topp og blir horisontal scroll på mobil/tablet
- Responsiv fontstørrelse på fokus-timer (72px → 48px → 40px)
- Responsiv tittel (32px → 24px → 20px)
- Padding justert for mobil og tablet